### PR TITLE
Fix for resource type capability

### DIFF
--- a/lib/puppet/type/hbm.rb
+++ b/lib/puppet/type/hbm.rb
@@ -80,7 +80,7 @@ Puppet::Type.newtype(:hbm) do
   newparam(:type) do
     desc "Resource's type."
 
-    newvalues(:action, :cap, :config, :device, :dns, :image, :logdriver, :logopt, :port, :registry, :volume)
+    newvalues(:action, :capability, :config, :device, :dns, :image, :logdriver, :logopt, :port, :registry, :volume)
   end
 
   newparam(:value) do


### PR DESCRIPTION
Hi, this is needed for hbm to add resources of type "capability".  It was a typo from the beginning, I guess it was never tested.