### PR TITLE
Rewrite match method to be compatible with puppet 3

### DIFF
--- a/lib/puppet/type/hbm.rb
+++ b/lib/puppet/type/hbm.rb
@@ -69,7 +69,7 @@ Puppet::Type.newtype(:hbm) do
     validate do |value|
       unless value.is_a?(Array)
         return raise ArgumentError, "Members must be an Array not #{value.class}" unless value.is_a?(String)
-        unless value match?(%r{^[a-z]{1}[a-zA-Z0-9\-\_]+$})
+        unless value =~ /^[a-z]{1}[a-zA-Z0-9\-\_]+$/
           raise ArgumentError, "Members value #{value} is not valid"
         end
       end

--- a/lib/puppet/type/hbm.rb
+++ b/lib/puppet/type/hbm.rb
@@ -69,9 +69,11 @@ Puppet::Type.newtype(:hbm) do
     validate do |value|
       unless value.is_a?(Array)
         return raise ArgumentError, "Members must be an Array not #{value.class}" unless value.is_a?(String)
-        unless value match?(%r{^[a-z]{1}[a-zA-Z0-9\-\_]+$})
+        # rubocop:disable RegexpLiteral, RegexpMatch
+        unless value =~ /^[a-z]{1}[a-zA-Z0-9\-\_]+$/
           raise ArgumentError, "Members value #{value} is not valid"
         end
+        # rubocop:enable RegexpLiteral, RegexpMatch
       end
     end
   end


### PR DESCRIPTION
Fix issue: Validate method failed for class members: undefined method `match?'

Replacing the method by the classic style